### PR TITLE
Collect board cards before clearing slots

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -252,10 +252,16 @@ function preFlop() {
 		p.cards[1].src = "cards/1B.svg";
 	});
 
-	// Clear community cards from last hand
-	document.querySelectorAll("#community-cards .cardslot").forEach(slot => {
-		slot.innerHTML = "";
-	});
+        // Collect community cards into graveyard before clearing the slots
+        document.querySelectorAll("#community-cards .cardslot img").forEach(img => {
+                const code = img.src.match(/\/cards\/([2-9TJQKA][CDHS])\.svg$/);
+                if (code) cardGraveyard.push(code[1]);
+        });
+
+        // Clear community cards from last hand
+        document.querySelectorAll("#community-cards .cardslot").forEach(slot => {
+                slot.innerHTML = "";
+        });
 
 	// Remove players with zero chips from the table
 	const remainingPlayers = [];


### PR DESCRIPTION
## Summary
- preserve community cards before clearing them in `preFlop()` so that the deck in `dealCards()` is complete at the start of each round

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68417c5a405c8331bbcf75824d9adfc8