### PR TITLE
Fix bot-only round check loop

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -453,9 +453,15 @@ function startBettingRound() {
 			} else {
 				notifyPlayerAction(player, "check");
 			}
-			// Schedule nextPlayer after all notifications are shown
-			onAllNotifsDone = () => nextPlayer();
-			return;
+                        // Schedule next action once notifications clear
+                        onAllNotifsDone = () => {
+                                if (anyUncalled()) {
+                                        nextPlayer();
+                                } else {
+                                        setPhase();
+                                }
+                        };
+                       return;
 		}
 
 		// Always skip folded or all-in players


### PR DESCRIPTION
## Summary
- avoid infinite checking loops when all players are bots by scheduling the next phase if no actions remain

## Testing
- `pre-commit` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684492c1803c833180f25cc3855109c7