### PR TITLE
Fix bot action queue

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -478,7 +478,9 @@ function startBettingRound() {
 			}
                         // Schedule next action after a delay
                         enqueueBotAction(() => {
-                                if (anyUncalled()) {
+                                if (cycles < players.length) {
+                                        nextPlayer();
+                                } else if (anyUncalled()) {
                                         nextPlayer();
                                 } else {
                                         setPhase();


### PR DESCRIPTION
## Summary
- remove `onAllNotifsDone` and decouple bots from notifications
- queue bot actions using `BOT_ACTION_DELAY`
- clean up notification scheduling

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6844ae6e6a0483318013546b553c7850