### PR TITLE
Simplify fold/all-in skipping in betting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -514,6 +514,20 @@ function startBettingRound() {
                        return nextPlayer();
                }
 
+               // Skip if player already matched the current bet
+               if (player.roundBet >= currentBet) {
+                       // Allow one pass-through for Big Blind pre-flop or Check post-flop
+                       if (
+                               (currentPhaseIndex === 0 && cycles <= players.length) ||
+                               (currentPhaseIndex > 0 && currentBet === 0 && cycles <= players.length)
+                       ) {
+                               // within first cycle: let them act
+                       } else {
+                               if (anyUncalled()) return nextPlayer();
+                               return setPhase();
+                       }
+               }
+
 		// If this is a bot, choose an action based on hand strength
 		if (player.isBot) {
 			document.querySelectorAll(".seat").forEach(s => s.classList.remove("active"));
@@ -556,19 +570,7 @@ function startBettingRound() {
 			return;
 		}
 
-		// Only check roundBet for skipping/termination
-		if (player.roundBet >= currentBet) {
-			// Allow one pass-through for Big Blind pre-flop or Check post-flop
-			if (
-				(currentPhaseIndex === 0 && cycles <= players.length) ||
-				(currentPhaseIndex > 0 && currentBet === 0 && cycles <= players.length)
-			) {
-				// within first cycle: let them act (Big Blind gets checked, others check post-flop)
-			} else {
-				if (anyUncalled()) return nextPlayer();
-				return setPhase();
-			}
-		}
+
 
 		// Highlight active player
 		// remove previous highlight

--- a/js/app.js
+++ b/js/app.js
@@ -504,23 +504,15 @@ function startBettingRound() {
 		}
 
 		// -------------------------------------------------------------------
-                // Find next player who still owes action
-                let player = players[idx % players.length];
-                idx++;
-                cycles++;
+               // Find next player who still owes action
+               let player = players[idx % players.length];
+               idx++;
+               cycles++;
 
-                // Unified skip-check: continue until we hit a player
-                // who is neither folded nor all-in
-                while (player.folded || player.allIn) {
-                        // If we've looped through everyone and nobody can act,
-                        // move to the next phase to avoid an infinite loop
-                        if (cycles >= players.length) {
-                                return setPhase();
-                        }
-                        player = players[idx % players.length];
-                        idx++;
-                        cycles++;
-                }
+               // Skip folded or all-in players immediately
+               if (player.folded || player.allIn) {
+                       return nextPlayer();
+               }
 
 		// If this is a bot, choose an action based on hand strength
 		if (player.isBot) {

--- a/js/app.js
+++ b/js/app.js
@@ -504,16 +504,23 @@ function startBettingRound() {
 		}
 
 		// -------------------------------------------------------------------
-		// Find next player who still owes action
-		let player = players[idx % players.length];
-		idx++;
-		cycles++;
+                // Find next player who still owes action
+                let player = players[idx % players.length];
+                idx++;
+                cycles++;
 
-		// Always skip folded or all-in players first
-		if (player.folded || player.allIn) {
-			// Skip this seat – guard clause at the top ensures we won't recurse forever
-			return nextPlayer();
-		}
+                // Unified skip-check: continue until we hit a player
+                // who is neither folded nor all-in
+                while (player.folded || player.allIn) {
+                        // If we've looped through everyone and nobody can act,
+                        // move to the next phase to avoid an infinite loop
+                        if (cycles >= players.length) {
+                                return setPhase();
+                        }
+                        player = players[idx % players.length];
+                        idx++;
+                        cycles++;
+                }
 
 		// If this is a bot, choose an action based on hand strength
 		if (player.isBot) {


### PR DESCRIPTION
## Summary
- unify folded/all-in skip logic in `nextPlayer()`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844d3377a408331bc07e70c2c478725