### PR TITLE
Improve bot betting logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -50,6 +50,11 @@ function formatCard(code) {
         return code[0].replace("T", "10") + SUIT_SYMBOLS[code[1]];
 }
 
+// Round a value to the nearest multiple of 10
+function roundTo10(x) {
+        return Math.round(x / 10) * 10;
+}
+
 // Clubs, Diamonds, Hearts, Spades
 // 2,3,4,5,6,7,8,9,T,J,Q,K,A
 let cards = [
@@ -184,19 +189,21 @@ function chooseBotAction(player) {
        // If no bet to call, decide whether to raise or check
        if (needToCall <= 0) {
                if (canRaise && strength >= raiseThreshold) {
-                       const raiseAmt = Math.min(
+                       let raiseAmt = Math.min(
                                player.chips,
                                Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
                        );
+                       raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
                        decision = { action: "raise", amount: raiseAmt };
                } else {
                        decision = { action: "check" };
                }
        } else if (canRaise && strength >= raiseThreshold && stackRatio <= 1 / 3) {
-               const raiseAmt = Math.min(
+               let raiseAmt = Math.min(
                        player.chips,
                        Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
                );
+               raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
                decision = { action: "raise", amount: raiseAmt };
        } else if (strengthRatio * aggressiveness >= potOdds && stackRatio <= 0.5) {
                const callAmt = Math.min(player.chips, needToCall);

--- a/js/app.js
+++ b/js/app.js
@@ -35,24 +35,24 @@ const BOT_ACTION_DELAY = 1500;
 const NOTIF_INTERVAL = 750;
 
 // Toggle verbose logging of bot decisions
-const DEBUG_DECISIONS = false;
+const DEBUG_DECISIONS = true;
 
 // Limit raises per betting round to prevent endless escalation
 const MAX_RAISES_PER_ROUND = 3;
 let raisesThisRound = 0;
 
 function logDecision(msg) {
-        if (DEBUG_DECISIONS) console.log(msg);
+	if (DEBUG_DECISIONS) console.log(msg);
 }
 
 const SUIT_SYMBOLS = { C: "♣", D: "♦", H: "♥", S: "♠" };
 function formatCard(code) {
-        return code[0].replace("T", "10") + SUIT_SYMBOLS[code[1]];
+	return code[0].replace("T", "10") + SUIT_SYMBOLS[code[1]];
 }
 
 // Round a value to the nearest multiple of 10
 function roundTo10(x) {
-        return Math.round(x / 10) * 10;
+	return Math.round(x / 10) * 10;
 }
 
 // Clubs, Diamonds, Hearts, Spades
@@ -102,129 +102,129 @@ function processBotQueue() {
 }
 
 function preflopHandScore(cardA, cardB) {
-        const order = "23456789TJQKA";
-        const base = { A: 10, K: 8, Q: 7, J: 6, T: 5, "9": 4.5, "8": 4, "7": 3.5, "6": 3, "5": 2.5, "4": 2, "3": 1.5, "2": 1 };
+	const order = "23456789TJQKA";
+	const base = { A: 10, K: 8, Q: 7, J: 6, T: 5, "9": 4.5, "8": 4, "7": 3.5, "6": 3, "5": 2.5, "4": 2, "3": 1.5, "2": 1 };
 
-        let r1 = cardA[0];
-        let r2 = cardB[0];
-        let s1 = cardA[1];
-        let s2 = cardB[1];
+	let r1 = cardA[0];
+	let r2 = cardB[0];
+	let s1 = cardA[1];
+	let s2 = cardB[1];
 
-        let i1 = order.indexOf(r1);
-        let i2 = order.indexOf(r2);
-        if (i1 < i2) {
-                [r1, r2] = [r2, r1];
-                [s1, s2] = [s2, s1];
-                [i1, i2] = [i2, i1];
-        }
+	let i1 = order.indexOf(r1);
+	let i2 = order.indexOf(r2);
+	if (i1 < i2) {
+		[r1, r2] = [r2, r1];
+		[s1, s2] = [s2, s1];
+		[i1, i2] = [i2, i1];
+	}
 
-        let score = base[r1];
-        if (r1 === r2) {
-                score *= 2;
-                if (score < 5) score = 5;
-        }
+	let score = base[r1];
+	if (r1 === r2) {
+		score *= 2;
+		if (score < 5) score = 5;
+	}
 
-        if (s1 === s2) score += 2;
+	if (s1 === s2) score += 2;
 
-        const gap = i1 - i2 - 1;
-        if (gap === 1) score -= 1;
-        else if (gap === 2) score -= 2;
-        else if (gap === 3) score -= 4;
-        else if (gap >= 4) score -= 5;
+	const gap = i1 - i2 - 1;
+	if (gap === 1) score -= 1;
+	else if (gap === 2) score -= 2;
+	else if (gap === 3) score -= 4;
+	else if (gap >= 4) score -= 5;
 
-        if (gap <= 1 && i1 < order.indexOf("Q")) score += 1;
+	if (gap <= 1 && i1 < order.indexOf("Q")) score += 1;
 
-        if (score < 0) score = 0;
+	if (score < 0) score = 0;
 
-        return Math.min(10, score);
+	return Math.min(10, score);
 }
 
 function chooseBotAction(player) {
-        const needToCall = currentBet - player.roundBet;
+	const needToCall = currentBet - player.roundBet;
 
-        // Additional factors for decision making
-       const potOdds = needToCall / (pot + needToCall);
-       const stackRatio = needToCall / player.chips;
-       const blindLevel = { small: smallBlind, big: bigBlind };
-       const canRaise = raisesThisRound < MAX_RAISES_PER_ROUND && player.chips > blindLevel.big;
+	// Additional factors for decision making
+	const potOdds = needToCall / (pot + needToCall);
+	const stackRatio = needToCall / player.chips;
+	const blindLevel = { small: smallBlind, big: bigBlind };
+	const canRaise = raisesThisRound < MAX_RAISES_PER_ROUND && player.chips > blindLevel.big;
 
-        // Determine position: early players act after big blind / dealer
-        const seatIdx = players.indexOf(player);
-        const refIdx = currentPhaseIndex === 0
-                ? (players.findIndex(p => p.bigBlind) + 1) % players.length
-                : (players.findIndex(p => p.dealer) + 1) % players.length;
-        const pos = (seatIdx - refIdx + players.length) % players.length;
-        const positionFactor = pos / (players.length - 1); // 0 = early, 1 = late
+	// Determine position: early players act after big blind / dealer
+	const seatIdx = players.indexOf(player);
+	const refIdx = currentPhaseIndex === 0
+		? (players.findIndex(p => p.bigBlind) + 1) % players.length
+		: (players.findIndex(p => p.dealer) + 1) % players.length;
+	const pos = (seatIdx - refIdx + players.length) % players.length;
+	const positionFactor = pos / (players.length - 1); // 0 = early, 1 = late
 
-       const communityCards = Array.from(
-               document.querySelectorAll("#community-cards .cardslot img")
-       ).map(img => {
-               const m = img.src.match(/\/cards\/([2-9TJQKA][CDHS])\.svg$/);
-               return m ? m[1] : null;
-       }).filter(Boolean);
+	const communityCards = Array.from(
+		document.querySelectorAll("#community-cards .cardslot img")
+	).map(img => {
+		const m = img.src.match(/\/cards\/([2-9TJQKA][CDHS])\.svg$/);
+		return m ? m[1] : null;
+	}).filter(Boolean);
 
-        const cards = [
-                player.cards[0].dataset.value,
-                player.cards[1].dataset.value,
-                ...communityCards
-        ];
+	const cards = [
+		player.cards[0].dataset.value,
+		player.cards[1].dataset.value,
+		...communityCards
+	];
 
-       const preflop = communityCards.length === 0;
+	const preflop = communityCards.length === 0;
 
-       let strength;
-       if (preflop) {
-               strength = preflopHandScore(player.cards[0].dataset.value, player.cards[1].dataset.value);
-       } else {
-               const hand = Hand.solve(cards);
-               strength = hand.rank;
-       }
+	let strength;
+	if (preflop) {
+		strength = preflopHandScore(player.cards[0].dataset.value, player.cards[1].dataset.value);
+	} else {
+		const hand = Hand.solve(cards);
+		strength = hand.rank;
+	}
 
-       // Normalize strength roughly between 0 and 1
-       const strengthRatio = strength / 10;
+	// Normalize strength roughly between 0 and 1
+	const strengthRatio = strength / 10;
 
-       const raiseBase = preflop
-               ? Math.max(blindLevel.big * (strength >= 8 ? 3 : 2), pot / 2)
-               : Math.max(blindLevel.big * 2, pot * 0.6);
-       const aggressiveness = preflop
-               ? 0.8 + 0.4 * positionFactor
-               : 1 + 0.6 * positionFactor;
-       const raiseThreshold = preflop
-               ? 8 - 2 * positionFactor
-               : Math.max(2, 4 - 2 * positionFactor);
+	const raiseBase = preflop
+		? Math.max(blindLevel.big * (strength >= 8 ? 3 : 2), pot / 2)
+		: Math.max(blindLevel.big * 2, pot * 0.6);
+	const aggressiveness = preflop
+		? 0.8 + 0.4 * positionFactor
+		: 1 + 0.6 * positionFactor;
+	const raiseThreshold = preflop
+		? 8 - 2 * positionFactor
+		: Math.max(2, 4 - 2 * positionFactor);
 
-       let decision;
+	let decision;
 
-       // If no bet to call, decide whether to raise or check
-       if (needToCall <= 0) {
-               if (canRaise && strength >= raiseThreshold) {
-                       let raiseAmt = Math.min(
-                               player.chips,
-                               Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
-                       );
-                       raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
-                       decision = { action: "raise", amount: raiseAmt };
-               } else {
-                       decision = { action: "check" };
-               }
-       } else if (canRaise && strength >= raiseThreshold && stackRatio <= 1 / 3) {
-               let raiseAmt = Math.min(
-                       player.chips,
-                       Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
-               );
-               raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
-               decision = { action: "raise", amount: raiseAmt };
-       } else if (strengthRatio * aggressiveness >= potOdds && stackRatio <= (preflop ? 0.5 : 0.7)) {
-               const callAmt = Math.min(player.chips, needToCall);
-               decision = { action: "call", amount: callAmt };
-       } else {
-               decision = { action: "fold" };
-       }
+	// If no bet to call, decide whether to raise or check
+	if (needToCall <= 0) {
+		if (canRaise && strength >= raiseThreshold) {
+			let raiseAmt = Math.min(
+				player.chips,
+				Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
+			);
+			raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
+			decision = { action: "raise", amount: raiseAmt };
+		} else {
+			decision = { action: "check" };
+		}
+	} else if (canRaise && strength >= raiseThreshold && stackRatio <= 1 / 3) {
+		let raiseAmt = Math.min(
+			player.chips,
+			Math.max(currentBet + blindLevel.big, raiseBase * (1 + positionFactor * 0.5))
+		);
+		raiseAmt = Math.min(player.chips, roundTo10(raiseAmt));
+		decision = { action: "raise", amount: raiseAmt };
+	} else if (strengthRatio * aggressiveness >= potOdds && stackRatio <= (preflop ? 0.5 : 0.7)) {
+		const callAmt = Math.min(player.chips, needToCall);
+		decision = { action: "call", amount: callAmt };
+	} else {
+		decision = { action: "fold" };
+	}
 
-       const h1 = formatCard(player.cards[0].dataset.value);
-       const h2 = formatCard(player.cards[1].dataset.value);
-       logDecision(`${player.name} [${h1} ${h2}] | strength=${strength.toFixed(2)} potOdds=${potOdds.toFixed(2)} stack=${stackRatio.toFixed(2)} pos=${positionFactor.toFixed(2)} raises=${raisesThisRound} -> ${decision.action}`);
+	const h1 = formatCard(player.cards[0].dataset.value);
+	const h2 = formatCard(player.cards[1].dataset.value);
+	logDecision(`${player.name} [${h1} ${h2}] | strength=${strength.toFixed(2)} potOdds=${potOdds.toFixed(2)} stack=${stackRatio.toFixed(2)} pos=${positionFactor.toFixed(2)} raises=${raisesThisRound} -> ${decision.action}`);
 
-       return decision;
+	return decision;
 }
 
 /* --------------------------------------------------------------------------------------------------
@@ -575,8 +575,8 @@ function startBettingRound() {
 		players.forEach(p => p.resetRoundBet());
 	}
 
-        raisesThisRound = 0;
-        let idx = startIdx;
+	raisesThisRound = 0;
+	let idx = startIdx;
 	let cycles = 0;
 
 	function anyUncalled() {
@@ -640,16 +640,16 @@ function startBettingRound() {
 				pot += actual;
 				document.querySelector("#pot").textContent = pot;
 				notifyPlayerAction(player, "call", actual);
-                        } else if (decision.action === "raise") {
-                                const amt = player.placeBet(decision.amount);
-                                if (amt > needToCall) {
-                                        currentBet = player.roundBet;
-                                }
-                                pot += amt;
-                                document.getElementById("pot").textContent = pot;
-                                notifyPlayerAction(player, "raise", player.roundBet);
-                                raisesThisRound++;
-                        }
+			} else if (decision.action === "raise") {
+				const amt = player.placeBet(decision.amount);
+				if (amt > needToCall) {
+					currentBet = player.roundBet;
+				}
+				pot += amt;
+				document.getElementById("pot").textContent = pot;
+				notifyPlayerAction(player, "raise", player.roundBet);
+				raisesThisRound++;
+			}
 
 			enqueueBotAction(() => {
 				if (cycles < players.length) {
@@ -720,17 +720,17 @@ function startBettingRound() {
 			if (bet === 0) {
 				// Check
 				notifyPlayerAction(player, "check");
-                        } else if (bet === player.chips) {
-                                // All-In
-                                player.placeBet(bet);
-                                pot += bet;
-                                document.getElementById("pot").textContent = pot;
-                                // If this all-in meets or exceeds the call amount, treat it as a raise
-                                if (bet >= needToCall) {
-                                        currentBet = player.roundBet;
-                                        raisesThisRound++;
-                                }
-                                notifyPlayerAction(player, "allin", bet);
+			} else if (bet === player.chips) {
+				// All-In
+				player.placeBet(bet);
+				pot += bet;
+				document.getElementById("pot").textContent = pot;
+				// If this all-in meets or exceeds the call amount, treat it as a raise
+				if (bet >= needToCall) {
+					currentBet = player.roundBet;
+					raisesThisRound++;
+				}
+				notifyPlayerAction(player, "allin", bet);
 				foldButton.removeEventListener("click", onFold);
 				actionButton.removeEventListener("click", onAction);
 				return nextPlayer();
@@ -740,15 +740,15 @@ function startBettingRound() {
 				pot += bet;
 				document.getElementById("pot").textContent = pot;
 				notifyPlayerAction(player, "call", player.roundBet);
-                        } else {
-                                // Raise
-                                player.placeBet(bet);
-                                currentBet = player.roundBet;
-                                pot += bet;
-                                document.getElementById("pot").textContent = pot;
-                                notifyPlayerAction(player, "raise", player.roundBet);
-                                raisesThisRound++;
-                        }
+			} else {
+				// Raise
+				player.placeBet(bet);
+				currentBet = player.roundBet;
+				pot += bet;
+				document.getElementById("pot").textContent = pot;
+				notifyPlayerAction(player, "raise", player.roundBet);
+				raisesThisRound++;
+			}
 
 			foldButton.removeEventListener("click", onFold);
 			actionButton.removeEventListener("click", onAction);

--- a/js/app.js
+++ b/js/app.js
@@ -84,9 +84,9 @@ function chooseBotAction(player) {
         const needToCall = currentBet - player.roundBet;
 
         // Additional factors for decision making
-        const potOdds = needToCall / (pot + needToCall);
-        const stackRatio = needToCall / player.chips;
-        const blindLevel = { smallBlind, bigBlind };
+       const potOdds = needToCall / (pot + needToCall);
+       const stackRatio = needToCall / player.chips;
+       const blindLevel = { small: smallBlind, big: bigBlind };
 
         const communityCards = Array.from(
                 document.querySelectorAll("#community-cards .cardslot img")
@@ -107,26 +107,28 @@ function chooseBotAction(player) {
         // Normalize strength roughly between 0 and 1
         const strengthRatio = strength / 10;
 
-        // If no bet to call, decide whether to raise or check
-        if (needToCall <= 0) {
-                if (strength >= 8 && player.chips > bigBlind) {
-                        const raiseAmt = Math.min(
-                                player.chips,
-                                Math.max(currentBet + bigBlind, pot / 2)
-                        );
-                        return { action: "raise", amount: raiseAmt };
-                }
-                return { action: "check" };
-        }
+       const raiseBase = Math.max(blindLevel.big * (strength >= 8 ? 3 : 2), pot / 2);
 
-        // Consider raising with strong hands when the required bet isn't too big
-        if (strength >= 8 && stackRatio <= 1 / 3) {
-                const raiseAmt = Math.min(
-                        player.chips,
-                        Math.max(currentBet + bigBlind, pot / 2)
-                );
-                return { action: "raise", amount: raiseAmt };
-        }
+       // If no bet to call, decide whether to raise or check
+       if (needToCall <= 0) {
+               if (strength >= 8 && player.chips > blindLevel.big) {
+                       const raiseAmt = Math.min(
+                               player.chips,
+                               Math.max(currentBet + blindLevel.big, raiseBase)
+                       );
+                       return { action: "raise", amount: raiseAmt };
+               }
+               return { action: "check" };
+       }
+
+       // Consider raising with strong hands when the required bet isn't too big
+       if (strength >= 8 && stackRatio <= 1 / 3) {
+               const raiseAmt = Math.min(
+                       player.chips,
+                       Math.max(currentBet + blindLevel.big, raiseBase)
+               );
+               return { action: "raise", amount: raiseAmt };
+       }
 
         // Call when pot odds justify it relative to hand strength
         if (strengthRatio >= potOdds && stackRatio <= 0.5) {

--- a/js/app.js
+++ b/js/app.js
@@ -80,6 +80,44 @@ function processBotQueue() {
 	}
 }
 
+function preflopHandScore(cardA, cardB) {
+        const order = "23456789TJQKA";
+        const base = { A: 10, K: 8, Q: 7, J: 6, T: 5, "9": 4.5, "8": 4, "7": 3.5, "6": 3, "5": 2.5, "4": 2, "3": 1.5, "2": 1 };
+
+        let r1 = cardA[0];
+        let r2 = cardB[0];
+        let s1 = cardA[1];
+        let s2 = cardB[1];
+
+        let i1 = order.indexOf(r1);
+        let i2 = order.indexOf(r2);
+        if (i1 < i2) {
+                [r1, r2] = [r2, r1];
+                [s1, s2] = [s2, s1];
+                [i1, i2] = [i2, i1];
+        }
+
+        let score = base[r1];
+        if (r1 === r2) {
+                score *= 2;
+                if (score < 5) score = 5;
+        }
+
+        if (s1 === s2) score += 2;
+
+        const gap = i1 - i2 - 1;
+        if (gap === 1) score -= 1;
+        else if (gap === 2) score -= 2;
+        else if (gap === 3) score -= 4;
+        else if (gap >= 4) score -= 5;
+
+        if (gap <= 1 && i1 <= order.indexOf("5")) score += 1;
+
+        if (score < 0) score = 0;
+
+        return Math.min(10, score / 2);
+}
+
 function chooseBotAction(player) {
         const needToCall = currentBet - player.roundBet;
 
@@ -101,8 +139,13 @@ function chooseBotAction(player) {
                 ...communityCards
         ];
 
-        const hand = Hand.solve(cards);
-        const strength = hand.rank;
+        let strength;
+        if (communityCards.length === 0) {
+                strength = preflopHandScore(player.cards[0].dataset.value, player.cards[1].dataset.value);
+        } else {
+                const hand = Hand.solve(cards);
+                strength = hand.rank;
+        }
 
         // Normalize strength roughly between 0 and 1
         const strengthRatio = strength / 10;

--- a/js/app.js
+++ b/js/app.js
@@ -118,11 +118,11 @@ function preflopHandScore(cardA, cardB) {
         else if (gap === 3) score -= 4;
         else if (gap >= 4) score -= 5;
 
-        if (gap <= 1 && i1 <= order.indexOf("5")) score += 1;
+        if (gap <= 1 && i1 < order.indexOf("Q")) score += 1;
 
         if (score < 0) score = 0;
 
-        return Math.min(10, score / 2);
+        return Math.min(10, score);
 }
 
 function chooseBotAction(player) {


### PR DESCRIPTION
## Summary
- add pot odds and stack ratio calculations
- update bot decision making to include hand strength, pot odds and bet sizing

## Testing
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6845fdbc5cd083318813d4391ddf1337