### PR TITLE
Add player stats for bot decisions

### DIFF
--- a/js/bot.js
+++ b/js/bot.js
@@ -316,7 +316,7 @@ export function chooseBotAction(player, ctx) {
         player.cards[1].dataset.value,
         ...communityCards
     ]).name : "preflop";
-    logDecision(`${player.name} [${h1} ${h2}] | strength=${strength.toFixed(2)} potOdds=${potOdds.toFixed(2)} stack=${stackRatio.toFixed(2)} pos=${positionFactor.toFixed(2)} raises=${raisesThisRound} -> ${decision.action} (${handName})`);
+    logDecision(`${player.name} [${h1} ${h2}] hand=${handName} str=${strengthRatio.toFixed(2)} potOdds=${potOdds.toFixed(2)} stack=${stackRatio.toFixed(2)} pos=${positionFactor.toFixed(2)} opp=${activeOpponents} thr=${raiseThreshold.toFixed(2)} aggr=${aggressiveness.toFixed(2)} -> ${decision.action}`);
 
     return decision;
 }

--- a/js/bot.js
+++ b/js/bot.js
@@ -216,18 +216,22 @@ export function chooseBotAction(player, ctx) {
             return s + (c > 0 ? a / c : a);
         }, 0) / opponents.length;
 
+        // Weight adjustments by average hands played to avoid overreacting in early rounds
+        const avgHands = opponents.reduce((s, p) => s + p.stats.hands, 0) / opponents.length;
+        const weight = Math.min(1, avgHands / 5); // ramp from 0 → 1 over first ~5 hands
+
         if (avgVPIP < 0.25) {
-            raiseThreshold -= 0.5;
-            aggressiveness += 0.1;
+            raiseThreshold -= 0.5 * weight;
+            aggressiveness += 0.1 * weight;
         } else if (avgVPIP > 0.5) {
-            raiseThreshold += 0.5;
-            aggressiveness -= 0.1;
+            raiseThreshold += 0.5 * weight;
+            aggressiveness -= 0.1 * weight;
         }
 
         if (avgAgg > 1.5) {
-            aggressiveness -= 0.1;
+            aggressiveness -= 0.1 * weight;
         } else if (avgAgg < 0.7) {
-            aggressiveness += 0.1;
+            aggressiveness += 0.1 * weight;
         }
     }
 


### PR DESCRIPTION
## Summary
- track statistics for each player (VPIP, PFR, aggression etc.)
- update stats on every action and at showdown
- use observed opponent stats inside the bot's decision logic

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846cac5a99c83319474eae178556fba