### PR TITLE
Add debug logging with Umami tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ The table works fully offline after the first complete load.
 
 ---
 
+## 🐞 Debug Logging
+
+Set `DEBUG_FLOW` to `true` in `js/app.js` to enable verbose console logs and
+[Umami](https://umami.is/) event tracking for each step of the betting loop.
+Use this when investigating hangs or unexpected behavior.
+
+---
+
 ## 📋 Known Limitations
 
 - No live syncing between devices — players act only via the shared table.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ The table works fully offline after the first complete load.
 ## 🐞 Debug Logging
 
 Set `DEBUG_FLOW` to `true` in `js/app.js` to print detailed, timestamped
-messages about the betting flow. Most of these logs are ignored by Umami using
-an internal `isBotLoop` flag so analytics aren't flooded. Only high level
-events like phase changes are tracked.
-Use this when investigating hangs or unexpected behavior.
+messages about the betting flow. Key events are always sent to Umami, while
+`isBotLoop` skips analytics from busy loops. Enable this flag when
+investigating hangs or unexpected behavior.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ The table works fully offline after the first complete load.
 ## 🐞 Debug Logging
 
 Set `DEBUG_FLOW` to `true` in `js/app.js` to print detailed, timestamped
-messages about the betting flow. Key events are always sent to Umami, while
-`isBotLoop` skips analytics from busy loops. Enable this flag when
-investigating hangs or unexpected behavior.
+messages about the betting flow. Enable this flag when investigating hangs or
+unexpected behavior.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ The table works fully offline after the first complete load.
 
 ## 🐞 Debug Logging
 
-Set `DEBUG_FLOW` to `true` in `js/app.js` to enable verbose console logs and
-[Umami](https://umami.is/) event tracking for each step of the betting loop.
+Set `DEBUG_FLOW` to `true` in `js/app.js` to print detailed, timestamped
+messages about the betting flow. Most of these logs are ignored by Umami using
+an internal `isBotLoop` flag so analytics aren't flooded. Only high level
+events like phase changes are tracked.
 Use this when investigating hangs or unexpected behavior.
 
 ---

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Secular+One&display=swap" rel="stylesheet">
-        <script defer src="https://cloud.umami.is/script.js" data-website-id="2392a451-203c-4d8a-a4f5-bd7d06f832af"></script>
 </head>
 <body>
 	<main>

--- a/index.html
+++ b/index.html
@@ -16,9 +16,12 @@
 	<link rel="icon" href="icons/poker-chip.svg" type="image/svg+xml">
 	<link rel="manifest" href="manifest.json">
 	<link rel="stylesheet" href="css/style.css">
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Secular+One&display=swap" rel="stylesheet">
+       <link rel="preconnect" href="https://fonts.googleapis.com">
+       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+       <link href="https://fonts.googleapis.com/css2?family=Secular+One&display=swap" rel="stylesheet">
+
+       <script defer src="https://cloud.umami.is/script.js"
+               data-website-id="2392a451-203c-4d8a-a4f5-bd7d06f832af"></script>
 </head>
 <body>
 	<main>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,8 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Secular+One&display=swap" rel="stylesheet">
-
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="2392a451-203c-4d8a-a4f5-bd7d06f832af"></script>
 </head>
-
 <body>
 	<main>
 		<div class="seat" data-rotation="0">

--- a/index.html
+++ b/index.html
@@ -20,8 +20,6 @@
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Secular+One&display=swap" rel="stylesheet">
 
-	<script defer src="https://cloud.umami.is/script.js"
-		data-website-id="2392a451-203c-4d8a-a4f5-bd7d06f832af"></script>
 </head>
 
 <body>

--- a/js/app.js
+++ b/js/app.js
@@ -82,14 +82,15 @@ function logHistory(msg) {
 }
 
 function logFlow(msg, data, isBotLoop = false) {
-       if (!DEBUG_FLOW) return;
-       const ts = new Date().toISOString().slice(11, 23);
-       if (data !== undefined) {
-               console.log("%c" + ts, "color:#888", msg, data);
-       } else {
-               console.log("%c" + ts, "color:#888", msg);
+       if (DEBUG_FLOW) {
+               const ts = new Date().toISOString().slice(11, 23);
+               if (data !== undefined) {
+                       console.log("%c" + ts, "color:#888", msg, data);
+               } else {
+                       console.log("%c" + ts, "color:#888", msg);
+               }
        }
-       if (isBotLoop) return;
+       if (isBotLoop) return; // avoid analytics spam from loops
        if (window.umami && typeof window.umami.track === "function") {
                const name = msg.slice(0, 50);
                try {

--- a/js/app.js
+++ b/js/app.js
@@ -343,13 +343,14 @@ function preFlop() {
 	// Remove players with zero chips from the table
 	const remainingPlayers = [];
 	players.forEach((p) => {
-		if (p.chips <= 0) {
-			p.chips = 0;
-			p.seat.classList.add("hidden");
-			enqueueNotification(`${p.name} is out of the game!`);
-		} else {
-			remainingPlayers.push(p);
-		}
+               if (p.chips <= 0) {
+                        p.chips = 0;
+                        p.seat.classList.add("hidden");
+                        enqueueNotification(`${p.name} is out of the game!`);
+                        logFlow("player_bust", { name: p.name });
+                } else {
+                        remainingPlayers.push(p);
+                }
 	});
 	players = remainingPlayers;
 
@@ -372,7 +373,7 @@ function preFlop() {
                 // Reveal champion's stack
                 champion.showTotal();
                 champion.seat.classList.add("winner");
-               logFlow("preFlop: champion");
+               logFlow("tournament_end", { champion: champion.name });
                return; // skip the rest of preFlop()
         }
 	// ----------------------------------------------------------

--- a/js/app.js
+++ b/js/app.js
@@ -81,14 +81,7 @@ function logHistory(msg) {
        if (HISTORY_LOG) console.log(msg);
 }
 
-function logFlow(msg, data, isBotLoop = false) {
-       if (!isBotLoop && typeof umami !== "undefined") {
-               try {
-                       umami.track(msg, data);
-               } catch (_) {
-                       /* ignore analytics errors */
-               }
-       }
+function logFlow(msg, data) {
        if (DEBUG_FLOW) {
                const ts = new Date().toISOString().slice(11, 23);
                if (data !== undefined) {
@@ -503,30 +496,29 @@ function startBettingRound() {
 		// -------------------------------------------------------------------
 		// Find next player who still owes action
 		const player = players[idx % players.length];
-               logFlow(
-                       "nextPlayer",
-                       {
-                               index: idx % players.length,
-                               cycles,
-                               name: player.name,
-                               folded: player.folded,
-                               allIn: player.allIn,
-                               roundBet: player.roundBet,
+                       logFlow(
+                               "nextPlayer",
+                               {
+                                       index: idx % players.length,
+                                       cycles,
+                                       name: player.name,
+                                       folded: player.folded,
+                                       allIn: player.allIn,
+                                       roundBet: player.roundBet,
                        },
-                       true,
                );
 		idx++;
 		cycles++;
 
 		// Skip folded or all-in players immediately
 				if (player.folded || player.allIn) {
-                                logFlow("skip folded/allin", { name: player.name }, true);
+                                logFlow("skip folded/allin", { name: player.name });
 				return setTimeout(nextPlayer, 0); // avoid recursive stack growth
 				}
 
 		// Skip if player already matched the current bet
 		if (player.roundBet >= currentBet) {
-                logFlow("already matched bet", { name: player.name, cycles }, true);
+                logFlow("already matched bet", { name: player.name, cycles });
 							// Allow one pass-through for Big Blind pre-flop or Check post-flop
 					if (
 						(currentPhaseIndex === 0 && cycles <= players.length) ||
@@ -535,10 +527,10 @@ function startBettingRound() {
 						// within first cycle: let them act
 					} else {
 										if (anyUncalled()) {
-                                                                               logFlow("wait uncalled", { name: player.name }, true);
+                                                                               logFlow("wait uncalled", { name: player.name });
 										return setTimeout(nextPlayer, 0); // schedule asynchronously to break call chain
 										}
-                                        logFlow("advance phase", { name: player.name }, true);
+                                        logFlow("advance phase", { name: player.name });
 					return setPhase();
 					}
 				}
@@ -595,13 +587,13 @@ function startBettingRound() {
 
                        enqueueBotAction(() => {
                                if (cycles < players.length) {
-                                       logFlow("bot next", { name: player.name }, true);
+                                       logFlow("bot next", { name: player.name });
                                        nextPlayer();
                                } else if (anyUncalled()) {
-                                       logFlow("bot wait", { name: player.name }, true);
+                                       logFlow("bot wait", { name: player.name });
                                        nextPlayer();
                                } else {
-                                       logFlow("bot advance", { name: player.name }, true);
+                                       logFlow("bot advance", { name: player.name });
                                        setPhase();
                                }
                        });
@@ -686,13 +678,13 @@ function startBettingRound() {
 				actionButton.removeEventListener("click", onAction);
 				// Decide whether to continue the betting loop or advance the phase
                                if (cycles < players.length) {
-                                       logFlow("human next", { name: player.name }, true);
+                                       logFlow("human next", { name: player.name });
                                        nextPlayer();
                                } else if (anyUncalled()) {
-                                       logFlow("human wait", { name: player.name }, true);
+                                       logFlow("human wait", { name: player.name });
                                        nextPlayer();
                                } else {
-                                       logFlow("human advance", { name: player.name }, true);
+                                       logFlow("human advance", { name: player.name });
                                        setPhase();
                                }
 				return;
@@ -722,13 +714,13 @@ function startBettingRound() {
 
 			// Decide whether to continue the betting loop or advance the phase
                        if (cycles < players.length) {
-                               logFlow("human next", { name: player.name }, true);
+                               logFlow("human next", { name: player.name });
                                nextPlayer();
                        } else if (anyUncalled()) {
-                               logFlow("human wait", { name: player.name }, true);
+                               logFlow("human wait", { name: player.name });
                                nextPlayer();
                        } else {
-                               logFlow("human advance", { name: player.name }, true);
+                               logFlow("human advance", { name: player.name });
                                setPhase();
                        }
 		}
@@ -742,13 +734,13 @@ function startBettingRound() {
 			actionButton.removeEventListener("click", onAction);
 			// Decide whether to continue the betting loop or advance the phase
                         if (cycles < players.length) {
-                                logFlow("fold next", { name: player.name }, true);
+                                logFlow("fold next", { name: player.name });
                                 nextPlayer();
                         } else if (anyUncalled()) {
-                                logFlow("fold wait", { name: player.name }, true);
+                                logFlow("fold wait", { name: player.name });
                                 nextPlayer();
                         } else {
-                                logFlow("fold advance", { name: player.name }, true);
+                                logFlow("fold advance", { name: player.name });
                                 setPhase();
                         }
 		}

--- a/js/app.js
+++ b/js/app.js
@@ -81,26 +81,13 @@ function logHistory(msg) {
        if (HISTORY_LOG) console.log(msg);
 }
 
-function logFlow(msg, data, isBotLoop = false) {
+function logFlow(msg, data) {
        if (DEBUG_FLOW) {
                const ts = new Date().toISOString().slice(11, 23);
                if (data !== undefined) {
                        console.log("%c" + ts, "color:#888", msg, data);
                } else {
                        console.log("%c" + ts, "color:#888", msg);
-               }
-       }
-       if (isBotLoop) return; // avoid analytics spam from loops
-       if (window.umami && typeof window.umami.track === "function") {
-               const name = msg.slice(0, 50);
-               try {
-                       if (data && typeof data === "object") {
-                               window.umami.track(name, data);
-                       } else {
-                               window.umami.track(name);
-                       }
-               } catch (_) {
-                       // ignore tracking failures
                }
        }
 }
@@ -509,26 +496,26 @@ function startBettingRound() {
 		// -------------------------------------------------------------------
 		// Find next player who still owes action
 		const player = players[idx % players.length];
-		logFlow("nextPlayer", {
-		index: idx % players.length,
-		cycles,
-		name: player.name,
-		folded: player.folded,
-		allIn: player.allIn,
-		roundBet: player.roundBet,
-		}, true);
+               logFlow("nextPlayer", {
+               index: idx % players.length,
+               cycles,
+               name: player.name,
+               folded: player.folded,
+               allIn: player.allIn,
+               roundBet: player.roundBet,
+               });
 		idx++;
 		cycles++;
 
 		// Skip folded or all-in players immediately
 				if (player.folded || player.allIn) {
-				logFlow("skip folded/allin", { name: player.name }, true);
+				logFlow("skip folded/allin", { name: player.name });
 				return setTimeout(nextPlayer, 0); // avoid recursive stack growth
 				}
 
 		// Skip if player already matched the current bet
 		if (player.roundBet >= currentBet) {
-		logFlow("already matched bet", { name: player.name, cycles }, true);
+		logFlow("already matched bet", { name: player.name, cycles });
 							// Allow one pass-through for Big Blind pre-flop or Check post-flop
 					if (
 						(currentPhaseIndex === 0 && cycles <= players.length) ||
@@ -537,7 +524,7 @@ function startBettingRound() {
 						// within first cycle: let them act
 					} else {
 										if (anyUncalled()) {
-										logFlow("wait uncalled", { name: player.name }, true);
+										logFlow("wait uncalled", { name: player.name });
 										return setTimeout(nextPlayer, 0); // schedule asynchronously to break call chain
 										}
 					logFlow("advance phase", { name: player.name });
@@ -597,13 +584,13 @@ function startBettingRound() {
 
                        enqueueBotAction(() => {
                                if (cycles < players.length) {
-                                       logFlow("bot next", { name: player.name }, true);
+                                       logFlow("bot next", { name: player.name });
                                        nextPlayer();
                                } else if (anyUncalled()) {
-                                       logFlow("bot wait", { name: player.name }, true);
+                                       logFlow("bot wait", { name: player.name });
                                        nextPlayer();
                                } else {
-                                       logFlow("bot advance", { name: player.name }, true);
+                                       logFlow("bot advance", { name: player.name });
                                        setPhase();
                                }
                        });
@@ -688,13 +675,13 @@ function startBettingRound() {
 				actionButton.removeEventListener("click", onAction);
 				// Decide whether to continue the betting loop or advance the phase
                                if (cycles < players.length) {
-                                       logFlow("human next", { name: player.name }, true);
+                                       logFlow("human next", { name: player.name });
                                        nextPlayer();
                                } else if (anyUncalled()) {
-                                       logFlow("human wait", { name: player.name }, true);
+                                       logFlow("human wait", { name: player.name });
                                        nextPlayer();
                                } else {
-                                       logFlow("human advance", { name: player.name }, true);
+                                       logFlow("human advance", { name: player.name });
                                        setPhase();
                                }
 				return;
@@ -724,13 +711,13 @@ function startBettingRound() {
 
 			// Decide whether to continue the betting loop or advance the phase
                        if (cycles < players.length) {
-                               logFlow("human next", { name: player.name }, true);
+                               logFlow("human next", { name: player.name });
                                nextPlayer();
                        } else if (anyUncalled()) {
-                               logFlow("human wait", { name: player.name }, true);
+                               logFlow("human wait", { name: player.name });
                                nextPlayer();
                        } else {
-                               logFlow("human advance", { name: player.name }, true);
+                               logFlow("human advance", { name: player.name });
                                setPhase();
                        }
 		}
@@ -744,13 +731,13 @@ function startBettingRound() {
 			actionButton.removeEventListener("click", onAction);
 			// Decide whether to continue the betting loop or advance the phase
                         if (cycles < players.length) {
-                                logFlow("fold next", { name: player.name }, true);
+                                logFlow("fold next", { name: player.name });
                                 nextPlayer();
                         } else if (anyUncalled()) {
-                                logFlow("fold wait", { name: player.name }, true);
+                                logFlow("fold wait", { name: player.name });
                                 nextPlayer();
                         } else {
-                                logFlow("fold advance", { name: player.name }, true);
+                                logFlow("fold advance", { name: player.name });
                                 setPhase();
                         }
 		}


### PR DESCRIPTION
## Summary
- instrument betting loop with `DEBUG_FLOW` logging helper
- track betting steps in Umami when `DEBUG_FLOW` is enabled
- document debugging flag in README

## Testing
- `deno fmt js/app.js README.md` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869445c2f2c8331801b65c9cc7b38c1