### PR TITLE
Adjust winner emoji cascade priority order

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -609,6 +609,10 @@ function getWinnerReactionEmoji(player, context) {
 		return getRandomItem(WINNER_REACTION_EMOJIS.reveal);
 	}
 
+	if (context.activePlayerCount === 1) {
+		return getRandomItem(WINNER_REACTION_EMOJIS.uncontested);
+	}
+
 	if (context.mainPotWinnerCount > 1) {
 		return getRandomItem(WINNER_REACTION_EMOJIS.split);
 	}
@@ -635,6 +639,10 @@ function getWinnerReactionEmoji(player, context) {
 		return getRandomItem(WINNER_REACTION_EMOJIS.allIn);
 	}
 
+	if (totalPayout >= Math.max(12 * context.bigBlind, stackBeforePayout)) {
+		return getRandomItem(WINNER_REACTION_EMOJIS.bigPot);
+	}
+
 	if (context.hadShowdown) {
 		const solvedHand = getVisibleSolvedHand(player, context.communityCards);
 		if (solvedHand) {
@@ -657,14 +665,6 @@ function getWinnerReactionEmoji(player, context) {
 		otherFinalStacks.length > 0 && otherFinalStacks.every((stack) => stack < stackAfterPayout)
 	) {
 		return getRandomItem(WINNER_REACTION_EMOJIS.chipLeader);
-	}
-
-	if (context.activePlayerCount === 1) {
-		return getRandomItem(WINNER_REACTION_EMOJIS.uncontested);
-	}
-
-	if (totalPayout >= Math.max(12 * context.bigBlind, stackBeforePayout)) {
-		return getRandomItem(WINNER_REACTION_EMOJIS.bigPot);
 	}
 
 	return getRandomItem(WINNER_REACTION_EMOJIS.fallback);


### PR DESCRIPTION
### Motivation
- The winner reaction selection needed to follow a new priority so that `reveal` and `uncontested` are evaluated earlier and `bigPot` is evaluated before showdown/hand-strength checks.
- This ensures the UI shows the most relevant emoji for different win scenarios according to the requested order.

### Description
- Reordered checks in `getWinnerReactionEmoji` so `uncontested` is evaluated immediately after `reveal` and before split-pot handling.
- Moved the `bigPot` check to run before showdown hand-strength (`monsterHand`/`strongHand`) and `chipLeader` checks.
- Preserved all existing emoji sets and fallback behavior so other conditions remain unchanged.

### Testing
- Ran a syntax check with `node --check js/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea55b32888331b0e9acaae0aaa4c8)